### PR TITLE
fix: switch MutationObserver debounce from trailing-edge to leading-edge

### DIFF
--- a/src/content/createAdMuter.ts
+++ b/src/content/createAdMuter.ts
@@ -18,7 +18,7 @@ export const createAdMuter = (config: AdMuterConfig) => {
   const isEnabled = createServiceToggle(config.serviceKey);
 
   let isMutedByExtension = false;
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let debounceActive = false;
 
   const checkForAds = () => {
     if (!isEnabled()) {
@@ -52,10 +52,12 @@ export const createAdMuter = (config: AdMuterConfig) => {
 
     if (targetNode) {
       const observer = new MutationObserver(() => {
-        if (debounceTimer !== null) {
-          clearTimeout(debounceTimer);
-        }
-        debounceTimer = setTimeout(checkForAds, DEBOUNCE_DELAY_MS);
+        if (debounceActive) return;
+        debounceActive = true;
+        checkForAds();
+        setTimeout(() => {
+          debounceActive = false;
+        }, DEBOUNCE_DELAY_MS);
       });
 
       observer.observe(


### PR DESCRIPTION
## Summary
- Fix YouTube ads not being muted after the debounce refactoring in #66
- Switch MutationObserver debounce from trailing-edge to leading-edge so `checkForAds()` executes immediately on the first mutation, then ignores subsequent mutations for 100ms

Closes #74

## Test plan
- [x] Load the extension on YouTube and verify ads are muted immediately
- [x] Confirm unmute works correctly when the ad ends
- [x] Verify no performance regression from frequent MutationObserver callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)