### PR TITLE
fix: reset lastKnownTime to 0 on video loadstart

### DIFF
--- a/src/content/youtube.ts
+++ b/src/content/youtube.ts
@@ -25,6 +25,7 @@ const startTimeTracking = () => {
         trackedVideo?.removeEventListener('loadstart', handleVideoLoadStart);
         video.addEventListener('loadstart', handleVideoLoadStart);
         trackedVideo = video;
+        lastKnownTime = 0;
       }
       lastKnownTime = Math.floor(video.currentTime);
     }

--- a/src/content/youtube.ts
+++ b/src/content/youtube.ts
@@ -9,6 +9,11 @@ const TIME_TRACKING_INTERVAL_MS = 1000;
 let reloadTimer: number | null = null;
 let lastKnownTime = 0;
 let timeTracker: number | null = null;
+let trackedVideo: HTMLVideoElement | null = null;
+
+const handleVideoLoadStart = () => {
+  lastKnownTime = 0;
+};
 
 const startTimeTracking = () => {
   stopTimeTracking();
@@ -16,6 +21,11 @@ const startTimeTracking = () => {
     if (document.querySelector(AD_SELECTOR)) return;
     const video = document.querySelector<HTMLVideoElement>(VIDEO_SELECTOR);
     if (video) {
+      if (video !== trackedVideo) {
+        trackedVideo?.removeEventListener('loadstart', handleVideoLoadStart);
+        video.addEventListener('loadstart', handleVideoLoadStart);
+        trackedVideo = video;
+      }
       lastKnownTime = Math.floor(video.currentTime);
     }
   }, TIME_TRACKING_INTERVAL_MS);


### PR DESCRIPTION
## Summary

- Reset `lastKnownTime` to `0` whenever the `<video>` element starts loading a new source, so the ad-triggered reload never seeks to a stale position from a previously played video.
- Attach the `loadstart` listener inside the existing `startTimeTracking` polling loop so it reliably follows the `<video>` element even after SPA navigation replaces it.
- Chose `loadstart` over `ended` because manual navigation to another video mid-playback does not fire `ended`, whereas `loadstart` covers autoplay, manual navigation, and reloads alike.

Closes #78

## Test plan

- [ ] Play a YouTube video partway, then navigate to a different video; confirm `lastKnownTime` resets (no seek to the previous position if an ad triggers a reload).
- [ ] Let a video autoplay into the next one and trigger an ad; confirm the reload seeks to the new video's start, not the previous video's end position.
- [ ] Open multiple YouTube tabs simultaneously and verify each tab tracks/resets its own state independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)